### PR TITLE
Remove lineup position source row from team edit

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1021,11 +1021,17 @@ function HomePageContent() {
         ? 3
         : undefined
 
-  const onboardingTargetSelector = showFirstDragHint || showArrowDragHint
-    ? '[data-onboarding="player-token"]'
-    : showPhaseNavigationHint
-      ? '[data-onboarding="phase-selector"]'
-      : ''
+  const onboardingTargetSelectors = showFirstDragHint
+    ? ['[data-onboarding="player-token"]']
+    : showArrowDragHint
+      ? [
+          '[data-onboarding="arrow-end-target"]',
+          '[data-onboarding="arrow-preview-target"]',
+          '[data-onboarding="player-token"]',
+        ]
+      : showPhaseNavigationHint
+        ? ['[data-onboarding="phase-selector"]']
+        : []
 
   useEffect(() => {
     if (previousPhaseRef.current === currentPhase) return
@@ -1379,18 +1385,21 @@ function HomePageContent() {
                 onTagsChange={isEditingAllowed ? (role, tags) => {
                   setTokenTags(currentRotation, currentPhase, role, tags)
                 } : undefined}
-                onPlayerAssign={isEditingAllowed && currentTeam ? (role, playerId) => {
-                  assignPlayerToRole(role, playerId)
-                } : undefined}
-	              />
+	                onPlayerAssign={isEditingAllowed && currentTeam ? (role, playerId) => {
+	                  assignPlayerToRole(role, playerId)
+	                } : undefined}
+                  suppressHoverHintTooltip={showFirstDragHint || showArrowDragHint}
+                  onboardingSpotlightRole={showArrowDragHint ? 'S' : null}
+                  showOnboardingArrowEndSpotlight={showArrowDragHint}
+		              />
 
-          <SpotlightOverlay
-            show={canShowOnboardingHint && Boolean(onboardingHintMessage)}
-            message={onboardingHintMessage || ''}
-            step={onboardingStep}
-            totalSteps={onboardingStep != null ? GUIDED_TOTAL : undefined}
-            targetSelector={onboardingTargetSelector}
-          />
+	          <SpotlightOverlay
+	            show={canShowOnboardingHint && Boolean(onboardingHintMessage)}
+	            message={onboardingHintMessage || ''}
+	            step={onboardingStep}
+	            totalSteps={onboardingStep != null ? GUIDED_TOTAL : undefined}
+	            targetSelectors={onboardingTargetSelectors}
+	          />
           </div>
         </div>
       </div>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -8,7 +8,7 @@ import { Id } from '@/convex/_generated/dataModel'
 import { getCurrentPositions, getCurrentArrows, getCurrentTags } from '@/lib/whiteboardHelpers'
 import { VolleyballCourt } from '@/components/court'
 import { RosterManagementCard } from '@/components/roster'
-import { Role, ROLES, RALLY_PHASES, Position, PositionCoordinates, RallyPhase, Team, CustomLayout, Lineup } from '@/lib/types'
+import { Role, ROLES, RALLY_PHASES, Position, PositionCoordinates, PositionAssignments, RallyPhase, Team, CustomLayout, Lineup } from '@/lib/types'
 import { getActiveAssignments } from '@/lib/lineups'
 import { getWhiteboardPositions } from '@/lib/whiteboard'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
@@ -34,6 +34,8 @@ import {
 } from '@/components/ui/select'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
 import { getLocalTeamById, listLocalTeams, upsertLocalTeam } from '@/lib/localTeams'
 import { generateSlug } from '@/lib/teamUtils'
 import { useHintStore } from '@/store/useHintStore'
@@ -150,6 +152,7 @@ function HomePageContent() {
   const lineupFromUrl = searchParams.get('lineup')?.trim() || ''
   const myTeams = useQuery(api.teams.listMyTeams, {})
   const updateLineups = useMutation(api.teams.updateLineups)
+  const updateRoster = useMutation(api.teams.updateRoster)
   const createTeam = useMutation(api.teams.create)
   const teamWithLayouts = useQuery(
     api.teams.getTeamWithLayouts,
@@ -159,6 +162,11 @@ function HomePageContent() {
   const selectedLayouts = teamWithLayouts?.layouts ?? undefined
   const [localTeams, setLocalTeams] = useState<Team[]>([])
   const [isSavingLineup, setIsSavingLineup] = useState(false)
+  const [isSavingLineupEditor, setIsSavingLineupEditor] = useState(false)
+  const [lineupDraftAssignments, setLineupDraftAssignments] = useState<PositionAssignments>({})
+  const [newLineupNameDraft, setNewLineupNameDraft] = useState('')
+  const [newCourtSetupPlayerName, setNewCourtSetupPlayerName] = useState('')
+  const [newCourtSetupPlayerNumber, setNewCourtSetupPlayerNumber] = useState('')
   const [isMounted, setIsMounted] = useState(false)
   const loadedTeamFromUrlRef = useRef<string | null>(null)
   const previousPhaseRef = useRef(currentPhase)
@@ -628,9 +636,60 @@ function HomePageContent() {
     }
     return currentTeam.lineups.find((lineup) => lineup.id === currentTeam.active_lineup_id) || currentTeam.lineups[0]
   }, [currentTeam])
+  const lineupRolesForSetup = useMemo(
+    () => (showLibero ? ROLES : ROLES.filter((role) => role !== 'L')),
+    [showLibero]
+  )
+  const currentLineupId = currentLineup?.id
+  const currentLineupAssignments = currentLineup?.position_assignments
+
+  useEffect(() => {
+    if (!currentLineupId) {
+      setLineupDraftAssignments({})
+      return
+    }
+    setLineupDraftAssignments(cleanAssignments(currentLineupAssignments || {}))
+  }, [cleanAssignments, currentLineupAssignments, currentLineupId])
+
+  const getDefaultLineupName = useCallback((lineups: Lineup[]) => {
+    const usedNames = new Set(lineups.map((lineup) => lineup.name.trim().toLowerCase()))
+    let nextIndex = lineups.length + 1
+    let nextName = `Lineup ${nextIndex}`
+    while (usedNames.has(nextName.toLowerCase())) {
+      nextIndex += 1
+      nextName = `Lineup ${nextIndex}`
+    }
+    return nextName
+  }, [])
+
+  const createLineupId = useCallback(() => {
+    return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `lineup-${Date.now()}`
+  }, [])
+
+  const assignmentSignature = useCallback((assignments: PositionAssignments) => {
+    return JSON.stringify(
+      Object.entries(assignments)
+        .filter(([, playerId]) => typeof playerId === 'string' && playerId.trim() !== '')
+        .sort(([left], [right]) => left.localeCompare(right))
+    )
+  }, [])
+
+  const cleanedLineupDraftAssignments = useMemo(
+    () => cleanAssignments(lineupDraftAssignments),
+    [lineupDraftAssignments, cleanAssignments]
+  )
+  const cleanedCurrentLineupAssignments = useMemo(
+    () => cleanAssignments(currentLineup?.position_assignments || {}),
+    [currentLineup?.position_assignments, cleanAssignments]
+  )
+  const lineupDraftHasChanges = useMemo(
+    () => assignmentSignature(cleanedLineupDraftAssignments) !== assignmentSignature(cleanedCurrentLineupAssignments),
+    [assignmentSignature, cleanedCurrentLineupAssignments, cleanedLineupDraftAssignments]
+  )
   const lineupSelectValue = currentLineup?.id || '__none__'
   const handleTeamSelect = useCallback((value: string) => {
-    setCourtSetupOpen(false)
     if (value === '__new__') {
       void handleNewTeamFromWhiteboard()
       return
@@ -712,7 +771,6 @@ function HomePageContent() {
     }
   }, [isAuthenticated, createTeam, router, setCurrentTeam])
   const handleLineupSelect = useCallback(async (value: string) => {
-    setCourtSetupOpen(false)
     if (value === '__none__') {
       return
     }
@@ -734,21 +792,13 @@ function HomePageContent() {
 
       const existingLineups = currentTeam.lineups || []
       const baseLineup = currentLineup || existingLineups[0]
-      const usedNames = new Set(existingLineups.map((lineup) => lineup.name.trim().toLowerCase()))
-      let nextIndex = existingLineups.length + 1
-      let nextName = `Lineup ${nextIndex}`
-      while (usedNames.has(nextName.toLowerCase())) {
-        nextIndex += 1
-        nextName = `Lineup ${nextIndex}`
-      }
+      const nextName = getDefaultLineupName(existingLineups)
 
       const clonedAssignments = {
         ...(baseLineup?.position_assignments || {}),
       }
       const newLineup: Lineup = {
-        id: typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-          ? crypto.randomUUID()
-          : `lineup-${Date.now()}`,
+        id: createLineupId(),
         name: nextName,
         position_assignments: clonedAssignments,
         position_source: baseLineup?.position_source ?? 'custom',
@@ -804,7 +854,149 @@ function HomePageContent() {
     } finally {
       setIsSavingLineup(false)
     }
-  }, [currentLineup, currentTeam, persistLineupsForTeam, router, setCurrentTeam])
+  }, [createLineupId, currentLineup, currentTeam, getDefaultLineupName, persistLineupsForTeam, router, setCurrentTeam])
+
+  const handleLineupDraftAssignmentChange = useCallback((role: Role, playerId: string | '__none__') => {
+    setLineupDraftAssignments((prev) => {
+      const next = { ...prev }
+      if (playerId === '__none__') {
+        delete next[role]
+      } else {
+        next[role] = playerId
+      }
+      return next
+    })
+  }, [])
+
+  const handleSaveSelectedLineupChanges = useCallback(async () => {
+    if (!currentTeam || !currentLineup) return
+
+    const updatedAssignments = cleanAssignments(lineupDraftAssignments)
+    const nextLineups = currentTeam.lineups.map((lineup) =>
+      lineup.id === currentLineup.id
+        ? { ...lineup, position_assignments: updatedAssignments }
+        : lineup
+    )
+    const nextTeam: Team = {
+      ...currentTeam,
+      lineups: nextLineups,
+      active_lineup_id: currentLineup.id,
+      position_assignments: updatedAssignments,
+    }
+
+    setIsSavingLineupEditor(true)
+    setCurrentTeam(nextTeam)
+    try {
+      await persistLineupsForTeam(nextTeam)
+      toast.success('Lineup updated')
+    } catch (error) {
+      setCurrentTeam(currentTeam)
+      const message = error instanceof Error ? error.message : 'Failed to update lineup'
+      toast.error(message)
+    } finally {
+      setIsSavingLineupEditor(false)
+    }
+  }, [cleanAssignments, currentLineup, currentTeam, lineupDraftAssignments, persistLineupsForTeam, setCurrentTeam])
+
+  const handleSaveAsNewLineupFromDraft = useCallback(async () => {
+    if (!currentTeam) return
+
+    const updatedAssignments = cleanAssignments(lineupDraftAssignments)
+    const existingLineups = currentTeam.lineups || []
+    const baseLineup = currentLineup || existingLineups[0]
+    const lineupName = newLineupNameDraft.trim() || getDefaultLineupName(existingLineups)
+    const newLineup: Lineup = {
+      id: createLineupId(),
+      name: lineupName,
+      position_assignments: updatedAssignments,
+      position_source: baseLineup?.position_source ?? 'custom',
+      starting_rotation: baseLineup?.starting_rotation ?? 1,
+      created_at: new Date().toISOString(),
+    }
+
+    const nextTeam: Team = {
+      ...currentTeam,
+      lineups: [...existingLineups, newLineup],
+      active_lineup_id: newLineup.id,
+      position_assignments: updatedAssignments,
+    }
+
+    setIsSavingLineupEditor(true)
+    setCurrentTeam(nextTeam)
+    try {
+      await persistLineupsForTeam(nextTeam)
+      setNewLineupNameDraft('')
+      toast.success(`Saved ${lineupName}`)
+    } catch (error) {
+      setCurrentTeam(currentTeam)
+      const message = error instanceof Error ? error.message : 'Failed to save new lineup'
+      toast.error(message)
+    } finally {
+      setIsSavingLineupEditor(false)
+    }
+  }, [
+    cleanAssignments,
+    createLineupId,
+    currentLineup,
+    currentTeam,
+    getDefaultLineupName,
+    lineupDraftAssignments,
+    newLineupNameDraft,
+    persistLineupsForTeam,
+    setCurrentTeam,
+  ])
+
+  const handleAddPlayerFromCourtSetup = useCallback(async () => {
+    if (!currentTeam) return
+
+    const name = newCourtSetupPlayerName.trim()
+    const number = newCourtSetupPlayerNumber.replace(/\D/g, '').slice(0, 3)
+    if (!name && !number) {
+      toast.error('Enter a player name, number, or both')
+      return
+    }
+
+    const nextPlayer = {
+      id: `player-${Date.now()}`,
+      name: name || undefined,
+      number: number ? parseInt(number, 10) : undefined,
+    }
+    const nextRoster = [...currentTeam.roster, nextPlayer]
+    const nextTeam: Team = {
+      ...currentTeam,
+      roster: nextRoster,
+    }
+
+    setIsSavingLineupEditor(true)
+    setCurrentTeam(nextTeam)
+    try {
+      if (nextTeam._id) {
+        await updateRoster({
+          id: nextTeam._id as Id<'teams'>,
+          roster: nextRoster,
+        })
+      } else {
+        upsertLocalTeam(nextTeam)
+        setLocalTeams(listLocalTeams())
+      }
+
+      setNewCourtSetupPlayerName('')
+      setNewCourtSetupPlayerNumber('')
+      toast.success('Player added')
+    } catch (error) {
+      setCurrentTeam(currentTeam)
+      const message = error instanceof Error ? error.message : 'Failed to add player'
+      toast.error(message)
+    } finally {
+      setIsSavingLineupEditor(false)
+    }
+  }, [
+    currentTeam,
+    newCourtSetupPlayerName,
+    newCourtSetupPlayerNumber,
+    setCurrentTeam,
+    updateRoster,
+  ])
 
   const canShowOnboardingHint = isMounted && isUiHydrated
   const showFirstDragHint = canShowOnboardingHint ? shouldShowFirstDragHint() : false
@@ -890,7 +1082,7 @@ function HomePageContent() {
         <Select
           value={lineupSelectValue}
           onValueChange={(value) => { void handleLineupSelect(value) }}
-          disabled={isSavingLineup}
+          disabled={isSavingLineup || isSavingLineupEditor}
         >
           <SelectTrigger className="h-9 text-sm">
             <SelectValue placeholder={currentTeam ? 'Select lineup' : 'Select team first'} />
@@ -898,7 +1090,6 @@ function HomePageContent() {
           <SelectContent>
             <SelectGroup>
               <SelectLabel>Actions</SelectLabel>
-              <SelectItem value="__new__">+ New Lineup...</SelectItem>
               <SelectItem value="__manage__">Manage Lineups...</SelectItem>
             </SelectGroup>
             <SelectSeparator />
@@ -926,6 +1117,104 @@ function HomePageContent() {
             )}
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-border bg-muted/40 px-3 py-3">
+        <div className="space-y-0.5">
+          <Label className="text-sm font-medium">Lineup Positions</Label>
+          <p className="text-xs text-muted-foreground">
+            Pick players for each role, then save to this lineup or save as a new one.
+          </p>
+        </div>
+        {!currentTeam ? (
+          <p className="text-xs text-muted-foreground">Select a team first.</p>
+        ) : (
+          <>
+            <div className="space-y-2">
+              {lineupRolesForSetup.map((role) => (
+                <div key={role} className="grid grid-cols-[72px_1fr] items-center gap-2">
+                  <span className="text-xs font-medium text-muted-foreground">{role}</span>
+                  <Select
+                    value={lineupDraftAssignments[role] || '__none__'}
+                    onValueChange={(value) => handleLineupDraftAssignmentChange(role, value as string | '__none__')}
+                    disabled={isSavingLineupEditor}
+                  >
+                    <SelectTrigger className="h-8 text-xs">
+                      <SelectValue placeholder="Unassigned" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none__">Unassigned</SelectItem>
+                      <SelectSeparator />
+                      {currentTeam.roster.map((player) => (
+                        <SelectItem key={player.id} value={player.id}>
+                          {(player.name && player.name.trim()) ? player.name : `Player ${player.number ?? ''}`.trim()}
+                          {player.number !== undefined ? ` #${player.number}` : ''}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <Button
+                size="sm"
+                onClick={() => { void handleSaveSelectedLineupChanges() }}
+                disabled={!currentLineup || !lineupDraftHasChanges || isSavingLineupEditor}
+              >
+                Save Lineup Changes
+              </Button>
+              <div className="flex flex-1 min-w-[220px] items-center gap-2">
+                <Input
+                  value={newLineupNameDraft}
+                  onChange={(event) => setNewLineupNameDraft(event.target.value)}
+                  placeholder="New lineup name (optional)"
+                  className="h-8 text-xs"
+                  disabled={isSavingLineupEditor}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => { void handleSaveAsNewLineupFromDraft() }}
+                  disabled={isSavingLineupEditor}
+                >
+                  Save as New
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2 border-t border-border/60 pt-3">
+              <Label className="text-xs text-muted-foreground">Add Player to Roster</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  value={newCourtSetupPlayerName}
+                  onChange={(event) => setNewCourtSetupPlayerName(event.target.value)}
+                  placeholder="Player name"
+                  className="h-8 text-xs"
+                  disabled={isSavingLineupEditor}
+                />
+                <Input
+                  value={newCourtSetupPlayerNumber}
+                  onChange={(event) => setNewCourtSetupPlayerNumber(event.target.value.replace(/\D/g, '').slice(0, 3))}
+                  placeholder="#"
+                  className="h-8 w-20 text-xs"
+                  inputMode="numeric"
+                  maxLength={3}
+                  disabled={isSavingLineupEditor}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => { void handleAddPlayerFromCourtSetup() }}
+                  disabled={isSavingLineupEditor || (!newCourtSetupPlayerName.trim() && !newCourtSetupPlayerNumber.trim())}
+                >
+                  Add
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
       </div>
 
       <div className="flex items-center justify-between rounded-lg border border-border bg-muted/40 px-3 py-2">
@@ -1115,7 +1404,7 @@ function HomePageContent() {
             <DialogHeader>
               <DialogTitle>Court Setup</DialogTitle>
               <DialogDescription>
-                Choose team, lineup, and opponent visibility for the whiteboard.
+                Choose a team, assign players to lineup positions, and control court display.
               </DialogDescription>
             </DialogHeader>
             {courtSetupContent}
@@ -1131,7 +1420,7 @@ function HomePageContent() {
             <SheetHeader className="pb-4">
               <SheetTitle>Court Setup</SheetTitle>
               <SheetDescription>
-                Choose team, lineup, and opponent visibility for the whiteboard.
+                Choose a team, assign players to lineup positions, and control court display.
               </SheetDescription>
             </SheetHeader>
             {courtSetupContent}
@@ -1151,7 +1440,7 @@ function HomePageContent() {
             <div className="mb-4 space-y-1.5">
               <h2 className="text-lg font-semibold leading-none tracking-tight">Court Setup</h2>
               <p className="text-sm text-muted-foreground">
-                Choose team, lineup, and opponent visibility for the whiteboard.
+                Choose a team, assign players to lineup positions, and control court display.
               </p>
             </div>
             {courtSetupContent}

--- a/app/(main)/teams/[id]/page.tsx
+++ b/app/(main)/teams/[id]/page.tsx
@@ -11,7 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { toast } from 'sonner'
 import { LineupSelector } from '@/components/roster/LineupSelector'
 import { PositionAssigner } from '@/components/roster/PositionAssigner'
-import type { Team, Lineup, PositionAssignments, PositionSource, Rotation } from '@/lib/types'
+import type { Team, Lineup, PositionAssignments, Rotation } from '@/lib/types'
 import { useTeamStore } from '@/store/useTeamStore'
 import { generateSlug } from '@/lib/teamUtils'
 import { getLocalTeamById, removeLocalTeam, upsertLocalTeam } from '@/lib/localTeams'
@@ -522,15 +522,6 @@ export default function TeamEditPage({ params }: TeamPageProps) {
     await persistLineups(nextLineups, activeLineupId)
   }
 
-  const handlePositionSourceChange = async (lineupId: string, source: PositionSource) => {
-    const nextLineups = lineups.map((lineup) =>
-      lineup.id === lineupId
-        ? { ...lineup, position_source: source }
-        : lineup
-    )
-    await persistLineups(nextLineups, activeLineupId)
-  }
-
   const handleStartingRotationChange = async (rotation: Rotation) => {
     if (!selectedLineupId) return
     const nextLineups = lineups.map((lineup) =>
@@ -644,7 +635,6 @@ export default function TeamEditPage({ params }: TeamPageProps) {
               onDuplicateLineup={(lineupId, newName) => { void handleDuplicateLineup(lineupId, newName) }}
               onDeleteLineup={(lineupId) => { void handleDeleteLineup(lineupId) }}
               onSetActiveLineup={(lineupId) => { void handleSetActiveLineup(lineupId) }}
-              onPositionSourceChange={(lineupId, source) => { void handlePositionSourceChange(lineupId, source) }}
               disabled={isSaving}
             />
             <PositionAssigner

--- a/app/(main)/teams/[id]/page.tsx
+++ b/app/(main)/teams/[id]/page.tsx
@@ -507,10 +507,6 @@ export default function TeamEditPage({ params }: TeamPageProps) {
     await persistLineups(filtered, nextActive, 'Lineup deleted')
   }
 
-  const handleSetActiveLineup = async (lineupId: string) => {
-    await persistLineups(lineups, lineupId, 'Active lineup updated')
-  }
-
   const handleAssignmentsChange = async (nextAssignments: PositionAssignments) => {
     if (!selectedLineupId) return
     setLineupAssignments(nextAssignments)
@@ -622,19 +618,17 @@ export default function TeamEditPage({ params }: TeamPageProps) {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Lineups</CardTitle>
-            <CardDescription>The active lineup is shown on the whiteboard. Use "Set as Active" in lineup actions.</CardDescription>
+            <CardDescription>Select a lineup to edit assignments and starting rotation.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <LineupSelector
               lineups={lineups}
               selectedLineupId={selectedLineupId}
-              activeLineupId={activeLineupId}
               onSelectLineup={handleSelectLineup}
               onCreateLineup={(name) => { void handleCreateLineup(name) }}
               onRenameLineup={(lineupId, newName) => { void handleRenameLineup(lineupId, newName) }}
               onDuplicateLineup={(lineupId, newName) => { void handleDuplicateLineup(lineupId, newName) }}
               onDeleteLineup={(lineupId) => { void handleDeleteLineup(lineupId) }}
-              onSetActiveLineup={(lineupId) => { void handleSetActiveLineup(lineupId) }}
               disabled={isSaving}
             />
             <PositionAssigner

--- a/app/(main)/teams/[id]/page.tsx
+++ b/app/(main)/teams/[id]/page.tsx
@@ -622,7 +622,7 @@ export default function TeamEditPage({ params }: TeamPageProps) {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Lineups</CardTitle>
-            <CardDescription>The active lineup is applied on the whiteboard.</CardDescription>
+            <CardDescription>The active lineup is shown on the whiteboard. Use "Set as Active" in lineup actions.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <LineupSelector

--- a/components/court/ArrowPreviewOverlay.tsx
+++ b/components/court/ArrowPreviewOverlay.tsx
@@ -41,6 +41,7 @@ interface ArrowPreviewOverlayProps {
     initialControlSvg?: { x: number; y: number }
   ) => void
   onPreviewHover: (role: Role, zone: 'token' | 'arrow', isEntering: boolean) => void
+  onboardingSpotlightRole?: Role | null
 }
 
 function ArrowPreviewOverlayImpl({
@@ -64,6 +65,7 @@ function ArrowPreviewOverlayImpl({
   onArrowChange,
   onArrowDragStart,
   onPreviewHover,
+  onboardingSpotlightRole = null,
 }: ArrowPreviewOverlayProps) {
   if (!onArrowChange) return null
 
@@ -117,25 +119,30 @@ function ArrowPreviewOverlayImpl({
             : homeSvgPos.y - previewCurveHeight,
         }
 
+        const spotlightTarget = onboardingSpotlightRole === role && isPreviewActive
         return (
-          <MovementArrow
+          <g
             key={`preview-${role}`}
-            start={previewStartSvg}
-            end={previewEndSvg}
-            control={previewControlSvg}
-            color={ROLE_INFO[role].color}
-            strokeWidth={3}
-            opacity={0.85}
-            isDraggable={true}
-            onDragStart={(e) => onArrowDragStart(role, e, previewEndSvg, previewControlSvg)}
-            onMouseEnter={() => !draggingRole && !draggingArrowRole && onPreviewHover(role, 'arrow', true)}
-            onMouseLeave={() => onPreviewHover(role, 'arrow', false)}
-            dragHitArea="both"
-            dragHandleRadius={32}
-            peekAnimated={true}
-            peekActive={isPreviewActive}
-            debugHitboxes={debugHitboxes}
-          />
+            {...(spotlightTarget ? { 'data-onboarding': 'arrow-preview-target' } : {})}
+          >
+            <MovementArrow
+              start={previewStartSvg}
+              end={previewEndSvg}
+              control={previewControlSvg}
+              color={ROLE_INFO[role].color}
+              strokeWidth={3}
+              opacity={0.85}
+              isDraggable={true}
+              onDragStart={(e) => onArrowDragStart(role, e, previewEndSvg, previewControlSvg)}
+              onMouseEnter={() => !draggingRole && !draggingArrowRole && onPreviewHover(role, 'arrow', true)}
+              onMouseLeave={() => onPreviewHover(role, 'arrow', false)}
+              dragHitArea="both"
+              dragHandleRadius={32}
+              peekAnimated={true}
+              peekActive={isPreviewActive}
+              debugHitboxes={debugHitboxes}
+            />
+          </g>
         )
       })}
     </g>

--- a/components/court/SpotlightOverlay.tsx
+++ b/components/court/SpotlightOverlay.tsx
@@ -8,7 +8,8 @@ interface SpotlightOverlayProps {
   message: string
   step?: number
   totalSteps?: number
-  targetSelector: string
+  targetSelector?: string
+  targetSelectors?: string[]
   /** Extra padding around the spotlight circle (px) */
   spotlightPadding?: number
 }
@@ -19,6 +20,7 @@ export function SpotlightOverlay({
   step,
   totalSteps,
   targetSelector,
+  targetSelectors,
   spotlightPadding = 12,
 }: SpotlightOverlayProps) {
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
@@ -28,7 +30,23 @@ export function SpotlightOverlay({
 
   // Measure the target element
   const measure = useCallback(() => {
-    const el = document.querySelector(targetSelector)
+    const selectors = targetSelectors && targetSelectors.length > 0
+      ? targetSelectors
+      : targetSelector
+        ? [targetSelector]
+        : []
+
+    if (selectors.length === 0) {
+      setTargetRect(null)
+      return
+    }
+
+    let el: Element | null = null
+    for (const selector of selectors) {
+      el = document.querySelector(selector)
+      if (el) break
+    }
+
     if (!el) {
       setTargetRect(null)
       return
@@ -36,7 +54,7 @@ export function SpotlightOverlay({
     const rect = el.getBoundingClientRect()
     setTargetRect(rect)
     setViewportSize({ w: window.innerWidth, h: window.innerHeight })
-  }, [targetSelector])
+  }, [targetSelector, targetSelectors])
 
   // Mount portal target
   useEffect(() => {

--- a/components/gametime/SetupScreen.tsx
+++ b/components/gametime/SetupScreen.tsx
@@ -652,20 +652,13 @@ function TeamCard({
       {isExpanded && hasMultipleLineups && (
         <div className="border-t border-border">
           {team.lineups.map((lineup) => {
-            const isActive = lineup.id === team.active_lineup_id
-
             return (
               <button
                 key={lineup.id}
                 onClick={() => onSelectLineup(lineup.id)}
                 className="w-full px-4 py-3 pl-8 text-left transition-colors hover:bg-accent active:bg-accent/80 flex items-center justify-between border-b border-border last:border-b-0"
               >
-                <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-sm truncate">{lineup.name}</span>
-                  {isActive && (
-                    <span className="text-[11px] text-primary font-medium shrink-0">(Active)</span>
-                  )}
-                </div>
+                <span className="text-sm truncate">{lineup.name}</span>
                 <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />
               </button>
             )

--- a/components/roster/LineupSelector.tsx
+++ b/components/roster/LineupSelector.tsx
@@ -9,6 +9,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
@@ -64,6 +65,7 @@ export function LineupSelector({
   onSetActiveLineup,
   disabled = false,
 }: LineupSelectorProps) {
+  const CREATE_LINEUP_VALUE = '__create_lineup__'
   const [dialogMode, setDialogMode] = useState<DialogMode>(null)
   const [dialogInput, setDialogInput] = useState('')
   const [targetLineupId, setTargetLineupId] = useState<string | null>(null)
@@ -143,6 +145,14 @@ export function LineupSelector({
     }
   }
 
+  const handleLineupValueChange = (value: string) => {
+    if (value === CREATE_LINEUP_VALUE) {
+      handleOpenDialog('create')
+      return
+    }
+    onSelectLineup(value)
+  }
+
   return (
     <div className="space-y-3">
       {/* Lineup selector row */}
@@ -150,7 +160,7 @@ export function LineupSelector({
         <div className="flex-1">
           <Select
             value={selectedLineupId || ''}
-            onValueChange={onSelectLineup}
+            onValueChange={handleLineupValueChange}
             disabled={disabled}
           >
             <SelectTrigger className="w-full">
@@ -170,20 +180,16 @@ export function LineupSelector({
                   </div>
                 </SelectItem>
               ))}
+              <SelectSeparator />
+              <SelectItem value={CREATE_LINEUP_VALUE}>
+                <div className="flex items-center gap-2 font-medium">
+                  <HugeiconsIcon icon={Add01Icon} className="h-4 w-4" />
+                  <span>Create lineup...</span>
+                </div>
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>
-
-        {/* New lineup button */}
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={() => handleOpenDialog('create')}
-          disabled={disabled}
-          aria-label="Create new lineup"
-        >
-          <HugeiconsIcon icon={Add01Icon} className="h-4 w-4" />
-        </Button>
 
         {/* More actions menu */}
         <DropdownMenu>

--- a/components/roster/LineupSelector.tsx
+++ b/components/roster/LineupSelector.tsx
@@ -236,25 +236,6 @@ export function LineupSelector({
         </DropdownMenu>
       </div>
 
-      {/* Active lineup indicator and position source selector */}
-      {selectedLineup && (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          {isActiveLineup ? (
-            <>
-              <HugeiconsIcon
-                icon={StarIcon}
-                className="h-3.5 w-3.5 text-amber-500 fill-amber-500"
-              />
-              <span>Active lineup (shown on whiteboard)</span>
-            </>
-          ) : (
-            <span className="text-muted-foreground/70">
-              Not the active lineup
-            </span>
-          )}
-        </div>
-      )}
-
       {/* Dialog for create/rename/duplicate */}
       <Dialog open={dialogMode !== null} onOpenChange={(open) => !open && handleCloseDialog()}>
         <DialogContent>

--- a/components/roster/LineupSelector.tsx
+++ b/components/roster/LineupSelector.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Lineup, PositionSource, POSITION_SOURCE_INFO } from '@/lib/types'
+import { Lineup } from '@/lib/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -34,7 +34,6 @@ import {
   Copy01Icon,
   PencilEdit01Icon,
   Delete02Icon,
-  LayoutGridIcon,
 } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
 
@@ -48,7 +47,6 @@ interface LineupSelectorProps {
   onDuplicateLineup: (lineupId: string, newName: string) => void
   onDeleteLineup: (lineupId: string) => void
   onSetActiveLineup: (lineupId: string) => void
-  onPositionSourceChange?: (lineupId: string, source: PositionSource) => void
   disabled?: boolean
 }
 
@@ -64,7 +62,6 @@ export function LineupSelector({
   onDuplicateLineup,
   onDeleteLineup,
   onSetActiveLineup,
-  onPositionSourceChange,
   disabled = false,
 }: LineupSelectorProps) {
   const [dialogMode, setDialogMode] = useState<DialogMode>(null)
@@ -241,74 +238,19 @@ export function LineupSelector({
 
       {/* Active lineup indicator and position source selector */}
       {selectedLineup && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {isActiveLineup ? (
-              <>
-                <HugeiconsIcon
-                  icon={StarIcon}
-                  className="h-3.5 w-3.5 text-amber-500 fill-amber-500"
-                />
-                <span>Active lineup (shown on whiteboard)</span>
-              </>
-            ) : (
-              <span className="text-muted-foreground/70">
-                Not the active lineup
-              </span>
-            )}
-          </div>
-
-          {/* Position source selector */}
-          {onPositionSourceChange && (
-            <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {isActiveLineup ? (
+            <>
               <HugeiconsIcon
-                icon={LayoutGridIcon}
-                className="h-4 w-4 text-muted-foreground flex-shrink-0"
+                icon={StarIcon}
+                className="h-3.5 w-3.5 text-amber-500 fill-amber-500"
               />
-              <Select
-                value={selectedLineup.position_source || 'custom'}
-                onValueChange={(v) => onPositionSourceChange(selectedLineup.id, v as PositionSource)}
-                disabled={disabled}
-              >
-                <SelectTrigger className="h-8 text-xs flex-1">
-                  <SelectValue placeholder="Position source" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="custom">
-                    <div className="flex flex-col items-start">
-                      <span className="font-medium">{POSITION_SOURCE_INFO['custom'].name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {POSITION_SOURCE_INFO['custom'].description}
-                      </span>
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="full-5-1">
-                    <div className="flex flex-col items-start">
-                      <span className="font-medium">{POSITION_SOURCE_INFO['full-5-1'].name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {POSITION_SOURCE_INFO['full-5-1'].description}
-                      </span>
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="5-1-libero">
-                    <div className="flex flex-col items-start">
-                      <span className="font-medium">{POSITION_SOURCE_INFO['5-1-libero'].name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {POSITION_SOURCE_INFO['5-1-libero'].description}
-                      </span>
-                    </div>
-                  </SelectItem>
-                  <SelectItem value="6-2">
-                    <div className="flex flex-col items-start">
-                      <span className="font-medium">{POSITION_SOURCE_INFO['6-2'].name}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {POSITION_SOURCE_INFO['6-2'].description}
-                      </span>
-                    </div>
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+              <span>Active lineup (shown on whiteboard)</span>
+            </>
+          ) : (
+            <span className="text-muted-foreground/70">
+              Not the active lineup
+            </span>
           )}
         </div>
       )}

--- a/components/roster/LineupSelector.tsx
+++ b/components/roster/LineupSelector.tsx
@@ -31,7 +31,6 @@ import {
 import {
   Add01Icon,
   MoreHorizontalIcon,
-  StarIcon,
   Copy01Icon,
   PencilEdit01Icon,
   Delete02Icon,
@@ -41,13 +40,11 @@ import { HugeiconsIcon } from '@hugeicons/react'
 interface LineupSelectorProps {
   lineups: Lineup[]
   selectedLineupId: string | null
-  activeLineupId: string | null
   onSelectLineup: (lineupId: string) => void
   onCreateLineup: (name: string) => void
   onRenameLineup: (lineupId: string, newName: string) => void
   onDuplicateLineup: (lineupId: string, newName: string) => void
   onDeleteLineup: (lineupId: string) => void
-  onSetActiveLineup: (lineupId: string) => void
   disabled?: boolean
 }
 
@@ -56,13 +53,11 @@ type DialogMode = 'create' | 'rename' | 'duplicate' | null
 export function LineupSelector({
   lineups,
   selectedLineupId,
-  activeLineupId,
   onSelectLineup,
   onCreateLineup,
   onRenameLineup,
   onDuplicateLineup,
   onDeleteLineup,
-  onSetActiveLineup,
   disabled = false,
 }: LineupSelectorProps) {
   const CREATE_LINEUP_VALUE = '__create_lineup__'
@@ -71,7 +66,6 @@ export function LineupSelector({
   const [targetLineupId, setTargetLineupId] = useState<string | null>(null)
 
   const selectedLineup = lineups.find(l => l.id === selectedLineupId)
-  const isActiveLineup = selectedLineupId === activeLineupId
 
   const handleOpenDialog = (mode: DialogMode, existingName = '', lineupId: string | null = null) => {
     setDialogMode(mode)
@@ -169,15 +163,7 @@ export function LineupSelector({
             <SelectContent>
               {lineups.map((lineup) => (
                 <SelectItem key={lineup.id} value={lineup.id}>
-                  <div className="flex items-center gap-2">
-                    {lineup.id === activeLineupId && (
-                      <HugeiconsIcon
-                        icon={StarIcon}
-                        className="h-3.5 w-3.5 text-amber-500 fill-amber-500"
-                      />
-                    )}
-                    <span>{lineup.name}</span>
-                  </div>
+                  <span>{lineup.name}</span>
                 </SelectItem>
               ))}
               <SelectSeparator />
@@ -204,15 +190,6 @@ export function LineupSelector({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {!isActiveLineup && (
-              <>
-                <DropdownMenuItem onClick={() => selectedLineupId && onSetActiveLineup(selectedLineupId)}>
-                  <HugeiconsIcon icon={StarIcon} className="h-4 w-4 mr-2" />
-                  Set as Active
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
             <DropdownMenuItem
               onClick={() =>
                 handleOpenDialog('rename', selectedLineup?.name || '', selectedLineupId)


### PR DESCRIPTION
## Summary
- remove the extra position-source control row from the lineup selector on team edit
- keep lineup selection/create/rename/duplicate/delete/active controls unchanged
- remove now-unused callback wiring from the team edit page

## Why
That row was an advanced system toggle and felt disconnected in this screen. This keeps the lineup editor focused on actions coaches actually use here.

## Verification
- npm run lint
- npm run build
