### PR TITLE
Refine C8 phase travel interactions

### DIFF
--- a/app/rebuild/prototypes/page.tsx
+++ b/app/rebuild/prototypes/page.tsx
@@ -415,90 +415,92 @@ export default function RebuildPrototypeLabPage() {
       ) : null}
 
       <main className="flex min-h-0 flex-1 flex-col justify-end overflow-hidden">
-        <section className="relative w-full shrink-0 overflow-visible" style={{ aspectRatio: mobileCourtAspectRatio }}>
-          <VolleyballCourt
-            positions={positions}
-            animationConfig={{ durationMs: playDurationMs }}
-            hideAwayTeam={hideAwayTeam}
-            awayTeamHidePercent={awayTeamHidePercent}
-            rotation={currentRotation}
-            roster={currentTeam?.roster || []}
-            assignments={currentTeam?.position_assignments || {}}
-            onPositionChange={
-              isEditingAllowed
-                ? (role, position) => {
-                    updateLocalPosition(currentRotation, rallyPhase, role, position)
-                  }
-                : undefined
-            }
-            arrows={currentArrows}
-            onArrowChange={
-              isEditingAllowed
-                ? (role, position) => {
-                    if (!position) {
-                      clearArrow(currentRotation, rallyPhase, role)
-                      return
+        <section className="flex min-h-0 flex-1 items-end overflow-visible">
+          <div className="relative w-full shrink-0 overflow-visible" style={{ aspectRatio: mobileCourtAspectRatio }}>
+            <VolleyballCourt
+              positions={positions}
+              animationConfig={{ durationMs: playDurationMs }}
+              hideAwayTeam={hideAwayTeam}
+              awayTeamHidePercent={awayTeamHidePercent}
+              rotation={currentRotation}
+              roster={currentTeam?.roster || []}
+              assignments={currentTeam?.position_assignments || {}}
+              onPositionChange={
+                isEditingAllowed
+                  ? (role, position) => {
+                      updateLocalPosition(currentRotation, rallyPhase, role, position)
                     }
+                  : undefined
+              }
+              arrows={currentArrows}
+              onArrowChange={
+                isEditingAllowed
+                  ? (role, position) => {
+                      if (!position) {
+                        clearArrow(currentRotation, rallyPhase, role)
+                        return
+                      }
 
-                    updateArrow(currentRotation, rallyPhase, role, position)
-                  }
-                : undefined
-            }
-            arrowCurves={currentArrowCurves}
-            onArrowCurveChange={
-              isEditingAllowed
-                ? (role, curve) => {
-                    setArrowCurve(currentRotation, rallyPhase, role, curve)
-                  }
-                : undefined
-            }
-            showPosition={showPosition}
-            showPlayer={showPlayer}
-            showNumber={showNumber}
-            circleTokens={circleTokens}
-            legalityViolations={violations}
-            showLibero={showLibero}
-            currentPhase={rallyPhase}
-            attackBallPosition={currentAttackBallPosition}
-            onAttackBallChange={
-              isEditingAllowed
-                ? (position) => {
-                    if (!position) {
-                      clearAttackBallPosition(currentRotation, rallyPhase)
-                      return
+                      updateArrow(currentRotation, rallyPhase, role, position)
                     }
+                  : undefined
+              }
+              arrowCurves={currentArrowCurves}
+              onArrowCurveChange={
+                isEditingAllowed
+                  ? (role, curve) => {
+                      setArrowCurve(currentRotation, rallyPhase, role, curve)
+                    }
+                  : undefined
+              }
+              showPosition={showPosition}
+              showPlayer={showPlayer}
+              showNumber={showNumber}
+              circleTokens={circleTokens}
+              legalityViolations={violations}
+              showLibero={showLibero}
+              currentPhase={rallyPhase}
+              attackBallPosition={currentAttackBallPosition}
+              onAttackBallChange={
+                isEditingAllowed
+                  ? (position) => {
+                      if (!position) {
+                        clearAttackBallPosition(currentRotation, rallyPhase)
+                        return
+                      }
 
-                    setAttackBallPosition(currentRotation, rallyPhase, position)
-                  }
-                : undefined
-            }
-            statusFlags={currentStatusFlags}
-            onStatusToggle={
-              isEditingAllowed
-                ? (role, status) => {
-                    togglePlayerStatus(currentRotation, rallyPhase, role, status)
-                  }
-                : undefined
-            }
-            fullStatusLabels={fullStatusLabels}
-            animationTrigger={playAnimationTrigger}
-            isPreviewingMovement={isPreviewingMovement}
-            tagFlags={currentTagFlags}
-            onTagsChange={
-              isEditingAllowed
-                ? (role, tags) => {
-                    setTokenTags(currentRotation, rallyPhase, role, tags)
-                  }
-                : undefined
-            }
-            onPlayerAssign={
-              isEditingAllowed
-                ? (role, playerId) => {
-                    assignPlayerToRole(role, playerId)
-                  }
-                : undefined
-            }
-          />
+                      setAttackBallPosition(currentRotation, rallyPhase, position)
+                    }
+                  : undefined
+              }
+              statusFlags={currentStatusFlags}
+              onStatusToggle={
+                isEditingAllowed
+                  ? (role, status) => {
+                      togglePlayerStatus(currentRotation, rallyPhase, role, status)
+                    }
+                  : undefined
+              }
+              fullStatusLabels={fullStatusLabels}
+              animationTrigger={playAnimationTrigger}
+              isPreviewingMovement={isPreviewingMovement}
+              tagFlags={currentTagFlags}
+              onTagsChange={
+                isEditingAllowed
+                  ? (role, tags) => {
+                      setTokenTags(currentRotation, rallyPhase, role, tags)
+                    }
+                  : undefined
+              }
+              onPlayerAssign={
+                isEditingAllowed
+                  ? (role, playerId) => {
+                      assignPlayerToRole(role, playerId)
+                    }
+                  : undefined
+              }
+            />
+          </div>
         </section>
 
         <section className="w-full shrink-0 overflow-visible" style={mobileDockStyle}>

--- a/app/rebuild/prototypes/page.tsx
+++ b/app/rebuild/prototypes/page.tsx
@@ -516,8 +516,8 @@ export default function RebuildPrototypeLabPage() {
       {isMobile ? (
         <div className="relative mx-auto flex h-full w-full flex-col overflow-hidden">{phoneShell}</div>
       ) : (
-        <div className="relative flex h-full w-full items-end justify-center overflow-hidden px-6 pb-4 pt-6">
-          <div className="flex w-full max-w-[960px] items-end justify-center gap-8">
+        <div className="relative flex h-full w-full items-center justify-center overflow-hidden px-6 pb-4">
+          <div className="flex h-full w-full max-w-[960px] items-center justify-center gap-8">
             <div className="relative flex shrink-0 items-center justify-center">
               <div
                 className="relative rounded-[44px] border border-white/12 bg-[linear-gradient(180deg,rgba(18,18,22,0.98)_0%,rgba(8,8,10,0.98)_100%)] p-[10px] shadow-[0_32px_60px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.06)]"

--- a/app/rebuild/prototypes/page.tsx
+++ b/app/rebuild/prototypes/page.tsx
@@ -516,8 +516,8 @@ export default function RebuildPrototypeLabPage() {
       {isMobile ? (
         <div className="relative mx-auto flex h-full w-full flex-col overflow-hidden">{phoneShell}</div>
       ) : (
-        <div className="relative flex h-full w-full items-center justify-center overflow-hidden px-6 pb-4">
-          <div className="flex h-full w-full max-w-[960px] items-center justify-center gap-8">
+        <div className="relative flex h-full w-full items-end justify-center overflow-hidden px-6 pb-4 pt-6">
+          <div className="flex w-full max-w-[960px] items-end justify-center gap-8">
             <div className="relative flex shrink-0 items-center justify-center">
               <div
                 className="relative rounded-[44px] border border-white/12 bg-[linear-gradient(180deg,rgba(18,18,22,0.98)_0%,rgba(8,8,10,0.98)_100%)] p-[10px] shadow-[0_32px_60px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.06)]"

--- a/app/rebuild/prototypes/page.tsx
+++ b/app/rebuild/prototypes/page.tsx
@@ -45,7 +45,9 @@ export default function RebuildPrototypeLabPage() {
     setActiveVariant,
     currentRotation,
     currentCorePhase,
+    targetCorePhase,
     isOurServe,
+    isPhaseTraveling,
     isPreviewingMovement,
     playAnimationTrigger,
     isLabTrayOpen,
@@ -210,8 +212,11 @@ export default function RebuildPrototypeLabPage() {
   }, [handleLoadDemoSeeds])
 
   const isEditingAllowed = !isPreviewingMovement
-  const nextByPlay = getNextByPlay(currentCorePhase)
-  const legalPlayLabel = getLegalPlayLabel(currentCorePhase)
+  const controlCorePhase = activeVariant === 'concept8' && isPhaseTraveling
+    ? targetCorePhase
+    : currentCorePhase
+  const nextByPlay = getNextByPlay(controlCorePhase)
+  const legalPlayLabel = getLegalPlayLabel(controlCorePhase)
   const scoringEnabled = canVariantScore(activeVariant)
   const handleTuningChange = useCallback((next: TactileTuning) => {
     setTactileTuning(next)
@@ -254,13 +259,15 @@ export default function RebuildPrototypeLabPage() {
       variantId={activeVariant}
       currentRotation={currentRotation}
       currentCorePhase={currentCorePhase}
+      targetCorePhase={targetCorePhase}
       nextByPlay={nextByPlay}
       legalPlayLabel={legalPlayLabel}
-      isFoundationalPhase={isFoundationalPhase(currentCorePhase)}
+      isFoundationalPhase={isFoundationalPhase(controlCorePhase)}
       isOurServe={isOurServe}
       canScore={scoringEnabled}
       connectorStyle={connectorStyle}
       playAnimationTrigger={playAnimationTrigger}
+      isPhaseTraveling={isPhaseTraveling}
       isPreviewingMovement={isPreviewingMovement}
       switchMotion={tactileTuning.switchMotion}
       tactileTuning={tactileTuning}

--- a/app/rebuild/prototypes/page.tsx
+++ b/app/rebuild/prototypes/page.tsx
@@ -223,6 +223,7 @@ export default function RebuildPrototypeLabPage() {
   }, [])
   const mobileDockHeight =
     activeVariant === 'concept4' ? tactileTuning.c4Literal.clusterLayout.dockHeight : tactileTuning.dock.collapsedHeight
+  const mobileDockStyle = activeVariant === 'concept4' ? { height: mobileDockHeight } : undefined
   const mobileCourtAspectRatio = '393 / 696'
 
   const labStatusCopy = `Rotation ${currentRotation} • ${formatCorePhaseLabel(currentCorePhase)} • ${
@@ -500,8 +501,8 @@ export default function RebuildPrototypeLabPage() {
           />
         </section>
 
-        <section className="w-full shrink-0 overflow-visible" style={{ height: mobileDockHeight }}>
-          <div className="flex h-full min-h-0 items-end overflow-visible">{prototypeControlPanel}</div>
+        <section className="w-full shrink-0 overflow-visible" style={mobileDockStyle}>
+          <div className="flex min-h-0 items-end overflow-visible">{prototypeControlPanel}</div>
         </section>
       </main>
     </>

--- a/app/rebuild/prototypes/page.tsx
+++ b/app/rebuild/prototypes/page.tsx
@@ -481,11 +481,12 @@ export default function RebuildPrototypeLabPage() {
                     }
                   : undefined
               }
-              fullStatusLabels={fullStatusLabels}
-              animationTrigger={playAnimationTrigger}
-              isPreviewingMovement={isPreviewingMovement}
-              tagFlags={currentTagFlags}
-              onTagsChange={
+            fullStatusLabels={fullStatusLabels}
+            animationTrigger={playAnimationTrigger}
+            isPreviewingMovement={isPreviewingMovement}
+            preserveAspectRatio="xMidYMax meet"
+            tagFlags={currentTagFlags}
+            onTagsChange={
                 isEditingAllowed
                   ? (role, tags) => {
                       setTokenTags(currentRotation, rallyPhase, role, tags)

--- a/components/court/VolleyballCourt.tsx
+++ b/components/court/VolleyballCourt.tsx
@@ -153,6 +153,8 @@ interface VolleyballCourtProps {
   onboardingSpotlightRole?: Role | null
   // Show a moving spotlight target on the arrow end while dragging
   showOnboardingArrowEndSpotlight?: boolean
+  // Override SVG alignment inside its container when letterboxing occurs
+  preserveAspectRatio?: string
 }
 
 type PlayAnimState = {
@@ -241,6 +243,7 @@ export function VolleyballCourt({
   suppressHoverHintTooltip = false,
   onboardingSpotlightRole = null,
   showOnboardingArrowEndSpotlight = false,
+  preserveAspectRatio = 'xMidYMid meet',
 }: VolleyballCourtProps) {
   // In simulation mode, disable editing
   const isEditable = mode === 'whiteboard' && editable
@@ -2209,7 +2212,7 @@ export function VolleyballCourt({
           // Disable webkit tap highlight on the entire SVG (mobile polish)
           WebkitTapHighlightColor: 'transparent',
         }}
-        preserveAspectRatio="xMidYMid meet"
+        preserveAspectRatio={preserveAspectRatio}
         role="img"
         aria-label={`Volleyball court ${rotation ? `rotation ${rotation}` : ''} phase ${showZones ? 'with zones' : ''}`}
         onClickCapture={(e) => {

--- a/components/rebuild/prototypes/Concept8FullLedPerimeter.tsx
+++ b/components/rebuild/prototypes/Concept8FullLedPerimeter.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
 import { cn } from '@/lib/utils'
 import type { CorePhase } from '@/lib/rebuild/prototypeFlow'
 import {
@@ -7,8 +9,7 @@ import {
   PhasePadHardwareLane,
   PhasePadJoystick,
   PhasePadRotationRail,
-  getQuarterTrackSegmentState,
-  usePhasePadTransition,
+  useQuarterTrackTravelState,
 } from './PhasePadShared'
 import type { PrototypeControlProps } from './types'
 
@@ -18,45 +19,73 @@ function PhaseAreaTile({
   phase,
   label,
   isActive,
+  switchMotion,
   onPhaseSelect,
 }: {
   phase: CorePhase
   label: string
   isActive: boolean
+  switchMotion: PrototypeControlProps['switchMotion']
   onPhaseSelect: (phase: CorePhase) => void
 }) {
+  const prefersReducedMotion = useReducedMotion()
+  const [isPressed, setIsPressed] = useState(false)
+  const transition = prefersReducedMotion
+    ? { duration: 0.001 }
+    : {
+        type: 'spring' as const,
+        stiffness: switchMotion.spring.stiffness,
+        damping: switchMotion.spring.damping,
+        mass: switchMotion.spring.mass,
+      }
+
   return (
     <button
       type="button"
       onClick={() => onPhaseSelect(phase)}
-      className={cn(
-        'relative flex min-h-[5.2rem] items-center justify-center border border-[rgba(135,154,170,0.22)] bg-[linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(236,241,245,0.96)_100%)] px-3 py-3 text-center text-[1.05rem] font-medium text-slate-800 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-primary/60',
-        isActive && 'bg-[linear-gradient(180deg,rgba(255,255,255,0.98)_0%,rgba(228,236,242,0.98)_100%)] text-slate-900'
-      )}
-      style={{
-        boxShadow: isActive
-          ? 'inset 0 0 0 1px rgba(255,255,255,0.62), inset 0 14px 22px rgba(255,255,255,0.24), 0 12px 22px rgba(148,163,184,0.14)'
-          : 'inset 0 0 0 1px rgba(255,255,255,0.48), 0 8px 18px rgba(148,163,184,0.08)',
-      }}
+      onPointerDown={() => setIsPressed(true)}
+      onPointerUp={() => setIsPressed(false)}
+      onPointerCancel={() => setIsPressed(false)}
+      onPointerLeave={() => setIsPressed(false)}
+      aria-pressed={isActive}
+      className="relative rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
     >
-      <span className="relative z-[1] tracking-[-0.02em]">{label}</span>
+      <motion.div
+        animate={{
+          scale: isPressed && !isActive ? 0.992 : isActive ? 0.985 : 1,
+          y: isPressed || isActive ? switchMotion.pressTravel : 0,
+        }}
+        transition={transition}
+        className={cn(
+          'lab-pressable relative flex min-h-[5.2rem] items-center justify-center border px-3 py-3 text-center text-[1.05rem] font-medium text-slate-800 transition-colors',
+          isActive ? 'lab-pressed border-border/80 text-slate-950' : 'border-border/55 text-slate-700'
+        )}
+        style={{
+          ['--lab-switch-knob-glow' as string]: switchMotion.knobGlow,
+          background: isActive
+            ? 'linear-gradient(180deg,rgba(241,245,248,0.98)_0%,rgba(216,224,230,0.98)_100%)'
+            : 'linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(236,241,245,0.96)_100%)',
+          borderColor: isActive ? 'rgba(117,132,145,0.62)' : 'rgba(135,154,170,0.28)',
+        }}
+      >
+        <span className="relative z-[1] tracking-[-0.02em]">{label}</span>
+      </motion.div>
     </button>
   )
 }
 
 export function Concept8FullLedPerimeter(props: PrototypeControlProps) {
-  const { transitionFrom, transitionTo, transitionProgress } = usePhasePadTransition(props)
   const hardwareTuning = props.tactileTuning.phasePadHardware
   const lanePadding = Math.max(8, hardwareTuning.trackWidth + 4.5)
-  const perimeterState = getQuarterTrackSegmentState({
+  const perimeterState = useQuarterTrackTravelState({
     currentCorePhase: props.currentCorePhase,
-    transitionFrom,
-    transitionTo,
-    transitionProgress,
-    isPreviewingMovement: props.isPreviewingMovement,
+    targetCorePhase: props.targetCorePhase,
+    isPhaseTraveling: props.isPhaseTraveling,
     positionsPerQuarter: hardwareTuning.piecesPerQuarter,
     phaseOrder: C8_PHASE_ORDER,
+    travelDurationMs: props.tactileTuning.c4Literal.connectorMotion.playDurationMs,
   })
+  const activePhase = props.isPhaseTraveling ? props.targetCorePhase : props.currentCorePhase
 
   return (
     <div className="flex w-full flex-col justify-end">
@@ -83,7 +112,8 @@ export function Concept8FullLedPerimeter(props: PrototypeControlProps) {
                   key={item.phase}
                   phase={item.phase}
                   label={item.label}
-                  isActive={item.phase === props.currentCorePhase && !props.isPreviewingMovement}
+                  isActive={item.phase === activePhase}
+                  switchMotion={props.switchMotion}
                   onPhaseSelect={props.onPhaseSelect}
                 />
               ))}

--- a/components/rebuild/prototypes/Concept8FullLedPerimeter.tsx
+++ b/components/rebuild/prototypes/Concept8FullLedPerimeter.tsx
@@ -48,21 +48,20 @@ function PhaseAreaTile({
       onPointerCancel={() => setIsPressed(false)}
       onPointerLeave={() => setIsPressed(false)}
       aria-pressed={isActive}
-      className="relative overflow-hidden rounded-none bg-[rgba(186,198,208,0.55)] outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+      className="relative rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
     >
       <motion.div
         animate={{
-          scale: isPressed && !isActive ? 0.994 : isActive ? 0.989 : 1,
-          y: isPressed || isActive ? switchMotion.pressTravel * 0.72 : 0,
+          scale: isPressed && !isActive ? 0.992 : isActive ? 0.985 : 1,
+          y: isPressed || isActive ? switchMotion.pressTravel : 0,
         }}
         transition={transition}
         className={cn(
-          'lab-pressable relative flex min-h-[5.2rem] h-full items-center justify-center rounded-none border px-3 py-3 text-center text-[1.05rem] font-medium text-slate-800 transition-colors',
+          'lab-pressable relative flex min-h-[5.2rem] items-center justify-center border px-3 py-3 text-center text-[1.05rem] font-medium text-slate-800 transition-colors',
           isActive ? 'lab-pressed border-border/80 text-slate-950' : 'border-border/55 text-slate-700'
         )}
         style={{
           ['--lab-switch-knob-glow' as string]: switchMotion.knobGlow,
-          transformOrigin: '50% 50%',
           background: isActive
             ? 'linear-gradient(180deg,rgba(241,245,248,0.98)_0%,rgba(216,224,230,0.98)_100%)'
             : 'linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(236,241,245,0.96)_100%)',
@@ -107,8 +106,7 @@ export function Concept8FullLedPerimeter(props: PrototypeControlProps) {
               totalLights={perimeterState.totalLights}
             />
 
-            <div className="relative z-[1] overflow-hidden rounded-[12px] border border-[rgba(186,198,208,0.58)] bg-[rgba(186,198,208,0.55)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]">
-              <div className="grid grid-cols-2 gap-px">
+            <div className="relative z-[1] grid grid-cols-2 gap-px overflow-hidden rounded-[12px] bg-[rgba(186,198,208,0.55)]">
               {PHASE_PAD_LAYOUT.map((item) => (
                 <PhaseAreaTile
                   key={item.phase}
@@ -119,7 +117,6 @@ export function Concept8FullLedPerimeter(props: PrototypeControlProps) {
                   onPhaseSelect={props.onPhaseSelect}
                 />
               ))}
-              </div>
             </div>
           </div>
 

--- a/components/rebuild/prototypes/Concept8FullLedPerimeter.tsx
+++ b/components/rebuild/prototypes/Concept8FullLedPerimeter.tsx
@@ -48,20 +48,21 @@ function PhaseAreaTile({
       onPointerCancel={() => setIsPressed(false)}
       onPointerLeave={() => setIsPressed(false)}
       aria-pressed={isActive}
-      className="relative rounded-[2px] outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+      className="relative overflow-hidden rounded-none bg-[rgba(186,198,208,0.55)] outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
     >
       <motion.div
         animate={{
-          scale: isPressed && !isActive ? 0.992 : isActive ? 0.985 : 1,
-          y: isPressed || isActive ? switchMotion.pressTravel : 0,
+          scale: isPressed && !isActive ? 0.994 : isActive ? 0.989 : 1,
+          y: isPressed || isActive ? switchMotion.pressTravel * 0.72 : 0,
         }}
         transition={transition}
         className={cn(
-          'lab-pressable relative flex min-h-[5.2rem] items-center justify-center border px-3 py-3 text-center text-[1.05rem] font-medium text-slate-800 transition-colors',
+          'lab-pressable relative flex min-h-[5.2rem] h-full items-center justify-center rounded-none border px-3 py-3 text-center text-[1.05rem] font-medium text-slate-800 transition-colors',
           isActive ? 'lab-pressed border-border/80 text-slate-950' : 'border-border/55 text-slate-700'
         )}
         style={{
           ['--lab-switch-knob-glow' as string]: switchMotion.knobGlow,
+          transformOrigin: '50% 50%',
           background: isActive
             ? 'linear-gradient(180deg,rgba(241,245,248,0.98)_0%,rgba(216,224,230,0.98)_100%)'
             : 'linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(236,241,245,0.96)_100%)',
@@ -106,7 +107,8 @@ export function Concept8FullLedPerimeter(props: PrototypeControlProps) {
               totalLights={perimeterState.totalLights}
             />
 
-            <div className="relative z-[1] grid grid-cols-2 gap-px overflow-hidden rounded-[12px] bg-[rgba(186,198,208,0.55)]">
+            <div className="relative z-[1] overflow-hidden rounded-[12px] border border-[rgba(186,198,208,0.58)] bg-[rgba(186,198,208,0.55)] shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]">
+              <div className="grid grid-cols-2 gap-px">
               {PHASE_PAD_LAYOUT.map((item) => (
                 <PhaseAreaTile
                   key={item.phase}
@@ -117,6 +119,7 @@ export function Concept8FullLedPerimeter(props: PrototypeControlProps) {
                   onPhaseSelect={props.onPhaseSelect}
                 />
               ))}
+              </div>
             </div>
           </div>
 

--- a/components/rebuild/prototypes/PhasePadShared.tsx
+++ b/components/rebuild/prototypes/PhasePadShared.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useReducedMotion } from 'motion/react'
 import { type CorePhase, formatCorePhaseLabel } from '@/lib/rebuild/prototypeFlow'
 import type { PhaseEmphasisTuning, PhasePadHardwareTuning } from '@/lib/rebuild/tactileTuning'
 import { TactilePlayJoystick } from './TactilePlayJoystick'
@@ -80,6 +81,100 @@ export function usePhasePadTransition(props: PrototypeControlProps) {
     transitionTo,
     transitionProgress,
     liveStatus,
+  }
+}
+
+export function useQuarterTrackTravelState({
+  currentCorePhase,
+  targetCorePhase,
+  isPhaseTraveling,
+  positionsPerQuarter,
+  phaseOrder,
+  travelDurationMs,
+}: {
+  currentCorePhase: CorePhase
+  targetCorePhase: CorePhase
+  isPhaseTraveling: boolean
+  positionsPerQuarter: number
+  phaseOrder: readonly CorePhase[]
+  travelDurationMs: number
+}) {
+  const prefersReducedMotion = useReducedMotion()
+  const segmentLength = positionsPerQuarter
+  const totalLights = positionsPerQuarter * phaseOrder.length
+  const restingStart = useMemo(
+    () => getQuarterTrackSegmentStart(currentCorePhase, positionsPerQuarter, phaseOrder),
+    [currentCorePhase, phaseOrder, positionsPerQuarter]
+  )
+  const segmentStartRef = useRef(restingStart)
+  const [segmentStart, setSegmentStart] = useState(restingStart)
+
+  useEffect(() => {
+    segmentStartRef.current = segmentStart
+  }, [segmentStart])
+
+  useEffect(() => {
+    if (!isPhaseTraveling) {
+      segmentStartRef.current = restingStart
+      setSegmentStart(restingStart)
+      return
+    }
+
+    const originStart = segmentStartRef.current
+    const goalStart = getQuarterTrackSegmentStart(targetCorePhase, positionsPerQuarter, phaseOrder)
+    const travelDelta = getShortestPerimeterDelta(originStart, goalStart, totalLights)
+
+    if (Math.abs(travelDelta) < 0.001) {
+      segmentStartRef.current = goalStart
+      setSegmentStart(goalStart)
+      return
+    }
+
+    const durationMs = prefersReducedMotion ? 1 : Math.max(1, travelDurationMs)
+    let frameId = 0
+    const startedAt = performance.now()
+
+    const tick = (now: number) => {
+      const progress = Math.min((now - startedAt) / durationMs, 1)
+      const nextStart = originStart + travelDelta * progress
+      segmentStartRef.current = nextStart
+      setSegmentStart(nextStart)
+
+      if (progress < 1) {
+        frameId = window.requestAnimationFrame(tick)
+      }
+    }
+
+    frameId = window.requestAnimationFrame(tick)
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+    }
+  }, [
+    currentCorePhase,
+    isPhaseTraveling,
+    phaseOrder,
+    positionsPerQuarter,
+    prefersReducedMotion,
+    restingStart,
+    targetCorePhase,
+    totalLights,
+    travelDurationMs,
+  ])
+
+  const liveStatus = useMemo(() => {
+    if (isPhaseTraveling) {
+      return `${formatCorePhaseLabel(currentCorePhase)} -> ${formatCorePhaseLabel(targetCorePhase)}`
+    }
+
+    return formatCorePhaseLabel(currentCorePhase)
+  }, [currentCorePhase, isPhaseTraveling, targetCorePhase])
+
+  return {
+    liveStatus,
+    segmentLength,
+    segmentStart,
+    totalLights,
   }
 }
 

--- a/components/rebuild/prototypes/types.ts
+++ b/components/rebuild/prototypes/types.ts
@@ -6,6 +6,7 @@ export interface PrototypeControlProps {
   variantId: PrototypeVariantId
   currentRotation: Rotation
   currentCorePhase: CorePhase
+  targetCorePhase: CorePhase
   nextByPlay: CorePhase
   legalPlayLabel: string
   isFoundationalPhase: boolean
@@ -13,6 +14,7 @@ export interface PrototypeControlProps {
   canScore: boolean
   connectorStyle: ConnectorStyle
   playAnimationTrigger: number
+  isPhaseTraveling: boolean
   isPreviewingMovement: boolean
   switchMotion: SwitchMotionTuning
   tactileTuning: TactileTuning

--- a/components/rebuild/prototypes/usePrototypeLabController.ts
+++ b/components/rebuild/prototypes/usePrototypeLabController.ts
@@ -16,13 +16,16 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
   const [activeVariant, setActiveVariant] = useState<PrototypeVariantId>('concept8')
   const [currentRotation, setCurrentRotation] = useState<Rotation>(1)
   const [currentCorePhase, setCurrentCorePhase] = useState<CorePhase>('SERVE')
+  const [targetCorePhase, setTargetCorePhase] = useState<CorePhase>('SERVE')
   const [isOurServe, setIsOurServe] = useState(true)
+  const [isPhaseTraveling, setIsPhaseTraveling] = useState(false)
   const [isPreviewingMovement, setPreviewingMovement] = useState(false)
   const [playAnimationTrigger, setPlayAnimationTrigger] = useState(0)
   const [isLabTrayOpen, setIsLabTrayOpen] = useState(false)
   const [connectorStyle, setConnectorStyle] = useState<ConnectorStyle>('sweep')
 
   const playTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const phaseCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const clearPlayTimer = useCallback(() => {
     if (!playTimerRef.current) return
@@ -30,16 +33,71 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
     playTimerRef.current = null
   }, [])
 
+  const clearPhaseCommitTimer = useCallback(() => {
+    if (!phaseCommitTimerRef.current) return
+    clearTimeout(phaseCommitTimerRef.current)
+    phaseCommitTimerRef.current = null
+  }, [])
+
   useEffect(() => {
     return () => {
       clearPlayTimer()
+      clearPhaseCommitTimer()
     }
-  }, [clearPlayTimer])
+  }, [clearPhaseCommitTimer, clearPlayTimer])
 
   const resetPreview = useCallback(() => {
     clearPlayTimer()
+    clearPhaseCommitTimer()
     setPreviewingMovement(false)
-  }, [clearPlayTimer])
+    setIsPhaseTraveling(false)
+    setTargetCorePhase(currentCorePhase)
+  }, [clearPhaseCommitTimer, clearPlayTimer, currentCorePhase])
+
+  const queuePhaseTravel = useCallback(
+    (nextPhase: CorePhase, options?: { previewMovement?: boolean; triggerPlayAnimation?: boolean }) => {
+      const previewMovement = options?.previewMovement ?? false
+      const triggerPlayAnimation = options?.triggerPlayAnimation ?? false
+      const shouldStartTravel =
+        isPhaseTraveling ||
+        isPreviewingMovement ||
+        nextPhase !== currentCorePhase
+
+      clearPlayTimer()
+      clearPhaseCommitTimer()
+
+      if (!shouldStartTravel) {
+        setPreviewingMovement(false)
+        setIsPhaseTraveling(false)
+        setTargetCorePhase(nextPhase)
+        return
+      }
+
+      setTargetCorePhase(nextPhase)
+      setIsPhaseTraveling(true)
+      setPreviewingMovement(previewMovement)
+
+      if (triggerPlayAnimation) {
+        setPlayAnimationTrigger((prev) => prev + 1)
+      }
+
+      phaseCommitTimerRef.current = setTimeout(() => {
+        setCurrentCorePhase(nextPhase)
+        setTargetCorePhase(nextPhase)
+        setIsPhaseTraveling(false)
+        setPreviewingMovement(false)
+        phaseCommitTimerRef.current = null
+      }, playAdvanceDelayMs)
+    },
+    [
+      clearPhaseCommitTimer,
+      clearPlayTimer,
+      currentCorePhase,
+      isPhaseTraveling,
+      isPreviewingMovement,
+      playAdvanceDelayMs,
+    ]
+  )
 
   const handleRotationSelect = useCallback(
     (rotation: Rotation) => {
@@ -51,10 +109,16 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
 
   const handlePhaseSelect = useCallback(
     (phase: CorePhase) => {
+      if (activeVariant === 'concept8') {
+        queuePhaseTravel(phase)
+        return
+      }
+
       resetPreview()
       setCurrentCorePhase(phase)
+      setTargetCorePhase(phase)
     },
-    [resetPreview]
+    [activeVariant, queuePhaseTravel, resetPreview]
   )
 
   const handlePlay = useCallback(() => {
@@ -63,7 +127,19 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
       return
     }
 
-    const nextPhase = getNextByPlay(currentCorePhase)
+    const basePhase = activeVariant === 'concept8' && isPhaseTraveling
+      ? targetCorePhase
+      : currentCorePhase
+    const nextPhase = getNextByPlay(basePhase)
+
+    if (activeVariant === 'concept8') {
+      queuePhaseTravel(nextPhase, {
+        previewMovement: true,
+        triggerPlayAnimation: true,
+      })
+      return
+    }
+
     setPlayAnimationTrigger((prev) => prev + 1)
     setPreviewingMovement(true)
     clearPlayTimer()
@@ -71,9 +147,20 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
     playTimerRef.current = setTimeout(() => {
       setPreviewingMovement(false)
       setCurrentCorePhase(nextPhase)
+      setTargetCorePhase(nextPhase)
       playTimerRef.current = null
     }, playAdvanceDelayMs)
-  }, [clearPlayTimer, currentCorePhase, isPreviewingMovement, playAdvanceDelayMs, resetPreview])
+  }, [
+    activeVariant,
+    clearPlayTimer,
+    currentCorePhase,
+    isPhaseTraveling,
+    isPreviewingMovement,
+    playAdvanceDelayMs,
+    queuePhaseTravel,
+    resetPreview,
+    targetCorePhase,
+  ])
 
   const handlePoint = useCallback(
     (winner: PointWinner) => {
@@ -91,6 +178,8 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
 
       setCurrentRotation(outcome.nextRotation)
       setCurrentCorePhase(outcome.nextCorePhase)
+      setTargetCorePhase(outcome.nextCorePhase)
+      setIsPhaseTraveling(false)
       setIsOurServe(outcome.nextIsOurServe)
     },
     [activeVariant, currentCorePhase, currentRotation, isOurServe, resetPreview]
@@ -100,6 +189,8 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
     resetPreview()
     setCurrentRotation(1)
     setCurrentCorePhase('SERVE')
+    setTargetCorePhase('SERVE')
+    setIsPhaseTraveling(false)
     setIsOurServe(true)
   }, [resetPreview])
 
@@ -108,7 +199,9 @@ export function usePrototypeLabController(playAdvanceDelayMs: number) {
     setActiveVariant,
     currentRotation,
     currentCorePhase,
+    targetCorePhase,
     isOurServe,
+    isPhaseTraveling,
     isPreviewingMovement,
     playAnimationTrigger,
     isLabTrayOpen,


### PR DESCRIPTION
## Summary
- give C8 phase tiles a tactile pressed active state tied to the target phase
- route tile taps, joystick quadrant selection, and joystick play through one continuous phase-travel model
- keep phase commits delayed until the caterpillar settles so retargeting stays smooth

## Verification
- npm run lint
- verified in isolated browser at http://localhost:3000/rebuild/prototypes:
  - tile target press updates before phase commit
  - phase commit settles after the travel window
  - rapid retargeting keeps the newest phase target
  - joystick play advances through the same travel model
