### PR TITLE
Fix Agentation hands-free local setup

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,10 @@
       "command": "npx",
       "args": [
         "agentation-mcp",
-        "server"
+        "server",
+        "--mcp-only",
+        "--http-url",
+        "http://127.0.0.1:4747"
       ],
       "env": {}
     }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,23 @@
 import type { NextConfig } from "next";
 
 const isProd = process.env.NODE_ENV === "production";
+const agentationEndpoint = process.env.NEXT_PUBLIC_AGENTATION_ENDPOINT;
+const agentationOrigin = agentationEndpoint
+  ? (() => {
+      try {
+        return new URL(agentationEndpoint).origin;
+      } catch {
+        return null;
+      }
+    })()
+  : null;
+const devConnectSources = [
+  "http://127.0.0.1:4747",
+  "http://localhost:4747",
+  agentationOrigin,
+]
+  .filter((value): value is string => Boolean(value))
+  .join(" ");
 const scriptSrc = isProd
   ? "script-src 'self' 'unsafe-inline'"
   : "script-src 'self' 'unsafe-inline' 'unsafe-eval'";
@@ -14,7 +31,7 @@ const contentSecurityPolicy = [
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob: https:",
   "font-src 'self' data:",
-  "connect-src 'self' https: wss: ws:",
+  `connect-src 'self' https: wss: ws:${!isProd && devConnectSources ? ` ${devConnectSources}` : ""}`,
 ].join("; ");
 
 const nextConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "npm": "10.x"
   },
   "scripts": {
+    "predev": "node scripts/require-node-22.mjs",
+    "prebuild": "node scripts/require-node-22.mjs",
     "dev": "npm-run-all --parallel dev:convex dev:next dev:agentation",
     "dev:agentation": "agentation-mcp server",
     "dev:convex": "convex dev",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "npm": "10.x"
   },
   "scripts": {
-    "dev": "npm-run-all --parallel dev:convex dev:next",
+    "dev": "npm-run-all --parallel dev:convex dev:next dev:agentation",
+    "dev:agentation": "agentation-mcp server",
     "dev:convex": "convex dev",
     "dev:next": "rm -rf .next && next dev",
+    "agentation:doctor": "agentation-mcp doctor",
     "build": "next build",
     "build:prod": "convex deploy --cmd 'next build'",
     "start": "next start",

--- a/scripts/require-node-22.mjs
+++ b/scripts/require-node-22.mjs
@@ -1,0 +1,15 @@
+const majorVersion = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
+
+if (majorVersion === 22) {
+  process.exit(0);
+}
+
+console.error(
+  [
+    "Volley Studio needs Node 22 to run cleanly.",
+    `You are currently on Node ${process.versions.node}.`,
+    "Switch to 22.22.0 from .nvmrc, then run the command again.",
+  ].join(" "),
+);
+
+process.exit(1);


### PR DESCRIPTION
## Summary
- allow the local preview to talk to the Agentation service in development without loosening production rules
- start the Agentation server alongside the local preview and add a quick doctor command
- point the project MCP config at the shared local Agentation HTTP service so browser notes and MCP tools use the same session stream

## Verification
- npm run lint
- npm run agentation:doctor
- confirmed `http://127.0.0.1:3000` loads locally
- confirmed the local preview created Agentation session `mmsmjek3-st2phl`
- confirmed pending annotations were visible through the MCP tools and resolved after test handling
